### PR TITLE
SM750 working branch

### DIFF
--- a/drivers/staging/sm750fb/sm750.h
+++ b/drivers/staging/sm750fb/sm750.h
@@ -217,4 +217,11 @@ int hw_sm750_pan_display(struct lynxfb_crtc *crtc,
 			 const struct fb_var_screeninfo *var,
 			 const struct fb_info *info);
 
+/*
+  * memcpy_io and memset_io functions that work on a raspberry pi 4
+  */
+void memcpy_fromio_pcie(void *to, const volatile void __iomem *from, size_t count);
+void memcpy_toio_pcie(volatile void __iomem *to, const void *from, size_t count);
+void memset_io_pcie(volatile void __iomem *dst, int c, size_t count);
+
 #endif

--- a/drivers/staging/sm750fb/sm750_hw.c
+++ b/drivers/staging/sm750fb/sm750_hw.c
@@ -79,7 +79,7 @@ int hw_sm750_map(struct sm750_dev *sm750_dev, struct pci_dev *pdev)
 
 	/* reserve the vidmem space of smi adaptor */
 	sm750_dev->pvMem =
-		ioremap_wc(sm750_dev->vidmem_start, sm750_dev->vidmem_size);
+		ioremap(sm750_dev->vidmem_start, sm750_dev->vidmem_size);
 	if (!sm750_dev->pvMem) {
 		pr_err("Map video memory failed\n");
 		ret = -EFAULT;


### PR DESCRIPTION
See https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/62

Apply this branch, compile the kernel, copy it to the Pi, and reboot.

`menuconfig` option:

```
Device Drivers
  -> Staging drivers
    -> Silicon Motion SM750 framebuffer support
```

(Or just search `/` in `menuconfig` for SM750, then when it shows up, press `1` to get to it, `[space]` to select it, and then save the options.)