### PR TITLE
Patched LSI/Broadcom mpt3sas driver for 64-bit BCM2711

### DIFF
--- a/drivers/scsi/mpt3sas/mpt3sas_base.c
+++ b/drivers/scsi/mpt3sas/mpt3sas_base.c
@@ -4091,7 +4091,8 @@ _base_mpi_ep_writeq(__u64 b, volatile void __iomem *addr,
  * care of 32 bit environment where its not quarenteed to send the entire word
  * in one transfer.
  */
-#if defined(writeq) && defined(CONFIG_64BIT)
+//#if defined(writeq) && defined(CONFIG_64BIT)
+#if 0  // See: https://github.com/raspberrypi/linux/issues/4158
 static inline void
 _base_writeq(__u64 b, volatile void __iomem *addr, spinlock_t *writeq_lock)
 {


### PR DESCRIPTION
See: https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/196 and https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/72

Apply this branch, compile the kernel, copy it to the Pi, and any supported LSI/Broadcom MegaRAID card (94xx series and later) _should_ work on the Pi.