### PR TITLE
AMD and Intel GPU support fixes for Raspberry Pi OS

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_display.c
+++ b/drivers/gpu/drm/i915/display/intel_display.c
@@ -7636,6 +7636,7 @@ int intel_atomic_commit(struct drm_device *dev, struct drm_atomic_state *_state,
 	 * FIXME: Cut over to (async) commit helpers instead of hand-rolling
 	 * everything.
 	 */
+#if defined(CONFIG_VGA_CONSOLE)
 	if (state->base.legacy_cursor_update) {
 		struct intel_crtc_state *new_crtc_state;
 		struct intel_crtc *crtc;
@@ -7644,6 +7645,7 @@ int intel_atomic_commit(struct drm_device *dev, struct drm_atomic_state *_state,
 		for_each_new_intel_crtc_in_state(state, crtc, new_crtc_state, i)
 			complete_all(&new_crtc_state->uapi.commit->flip_done);
 	}
+#endif
 
 	ret = intel_atomic_prepare_commit(state);
 	if (ret) {

--- a/drivers/gpu/drm/i915/display/intel_vga.c
+++ b/drivers/gpu/drm/i915/display/intel_vga.c
@@ -91,7 +91,9 @@ void intel_vga_reset_io_mem(struct intel_display *display)
 	 * and error messages.
 	 */
 	vga_get_uninterruptible(pdev, VGA_RSRC_LEGACY_IO);
+#if defined(CONFIG_VGA_CONSOLE)
 	outb(inb(VGA_MIS_R), VGA_MIS_W);
+#endif
 	vga_put(pdev, VGA_RSRC_LEGACY_IO);
 }
 

--- a/drivers/gpu/drm/ttm/ttm_bo_util.c
+++ b/drivers/gpu/drm/ttm/ttm_bo_util.c
@@ -348,8 +348,6 @@ static int ttm_bo_kmap_ttm(struct ttm_buffer_object *bo,
 		.no_wait_gpu = false
 	};
 	struct ttm_tt *ttm = bo->ttm;
-	struct ttm_resource_manager *man =
-			ttm_manager_type(bo->bdev, bo->resource->mem_type);
 	pgprot_t prot;
 	int ret;
 
@@ -359,17 +357,7 @@ static int ttm_bo_kmap_ttm(struct ttm_buffer_object *bo,
 	if (ret)
 		return ret;
 
-	if (num_pages == 1 && ttm->caching == ttm_cached &&
-	    !(man->use_tt && (ttm->page_flags & TTM_TT_FLAG_DECRYPTED))) {
-		/*
-		 * We're mapping a single page, and the desired
-		 * page protection is consistent with the bo.
-		 */
-
-		map->bo_kmap_type = ttm_bo_map_kmap;
-		map->page = ttm->pages[start_page];
-		map->virtual = kmap(map->page);
-	} else {
+	{
 		/*
 		 * We need to use vmap to get the desired page protection
 		 * or to make the buffer object look contiguous.

--- a/drivers/gpu/drm/ttm/ttm_module.c
+++ b/drivers/gpu/drm/ttm/ttm_module.c
@@ -63,7 +63,12 @@ pgprot_t ttm_prot_from_caching(enum ttm_caching caching, pgprot_t tmp)
 {
 	/* Cached mappings need no adjustment */
 	if (caching == ttm_cached)
+	{
+#ifdef CONFIG_ARM64
+		return pgprot_dmacoherent(tmp);
+#endif
 		return tmp;
+	}
 
 #if defined(__i386__) || defined(__x86_64__)
 	if (caching == ttm_write_combined)


### PR DESCRIPTION
See related issues:

  - [Testing yanghaku's DRM patch for cache coherency on various graphics cards](https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/764)
  - [Test AMD RX 9070 XT 16GB](https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/766)
  - [Test AMD RX 7900 XT 20GB](https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/763)
  - [Test Intel Arc B580 12GB](https://github.com/geerlingguy/raspberry-pi-pcie-devices/issues/695)

Also see @6by9's testing branch for debugging a few other cards, like the Intel Arc A350: https://github.com/raspberrypi/linux/pull/7072

HUGE thanks to @Coreforge, @yanghaku, @ifdu, @6by9, @RSC-Games, and countless others who have worked through untold thousands of lines of code to get it down to this point :D